### PR TITLE
add on-chain contracts reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Secp256r1 (a.k.a p256) curve signature verifier rewritten and optimized in [Huff
 
 ## Gas Benchmark
 
-| Implementation               | Min gas | Avg gas | Max gas |
-| ---------------------------- | ------- | ------- | ------- |
-| Huff P256 Verifier           | 228,475 | 239,164 | 249,574 |
-| Daimo Solidity P256 Verifier | 319,943 | 333,892 | 347,505 |
-| FCL Solidity P256 Verifier   | 362,028 | 378,868 | 394,931 |
+| Implementation               | Min gas | Avg gas | Max gas | OnChain Address                          | Available Networks                                     |
+| ---------------------------- | ------- | ------- | ------- |---------------- -------------------------|------------------------------------------------------- |
+| FCL Solidity P256 Verifier   |         |  	   | 227,000 |0xE9399D1183a5cf9E14B120875A616b6E2bcB840a|Polygon(M), Sepolia, Base, OP, Linea                    |
+| Huff P256 Verifier           | 228,475 | 239,164 | 249,574 |                                          |                                                        | 
+| Daimo Solidity P256 Verifier | 319,943 | 333,892 | 347,505 |0xc2b78104907F722DABAc4C69f826a522B2754De4|Mainnet, Base(T)                                        | 
+| Vyper P256 Verifier          |         |         |         |0xD99D0f622506C2521cceb80B78CAeBE1798C7Ed5|Sepolia, Holeski                                        |
+
 
 ## Actions
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Secp256r1 (a.k.a p256) curve signature verifier rewritten and optimized in [Huff
 ## Gas Benchmark
 
 | Implementation               | Min gas | Avg gas | Max gas | OnChain Address                          | Available Networks                                     |
-| ---------------------------- | ------- | ------- | ------- |---------------- -------------------------|------------------------------------------------------- |
+| ---------------------------- | ------- | ------- | ------- |------------------------------------------|------------------------------------------------------- |
 | FCL Solidity P256 Verifier   |         |  	   | 227,000 |0xE9399D1183a5cf9E14B120875A616b6E2bcB840a|Polygon(M), Sepolia, Base, OP, Linea                    |
 | Huff P256 Verifier           | 228,475 | 239,164 | 249,574 |                                          |                                                        | 
 | Daimo Solidity P256 Verifier | 319,943 | 333,892 | 347,505 |0xc2b78104907F722DABAc4C69f826a522B2754De4|Mainnet, Base(T)                                        | 

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,4 +6,6 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc = "0.8.21"
 evm_version = "shanghai"
 ffi = true
+optimizer = true
+optimizer_runs = 1000000
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
Benchmarks are not consistent with on-chain results (maybe because of --IR or number of steps of toml).

Providing on chain contracts to perform real world benchmarks.